### PR TITLE
Add function to get bib info from CITATION file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
  - pip install pytest codecov pytest-cov ipython nbformat nbconvert
  - pip install coverage coveralls
  # emcee is needed to test __bibtex__, and we need to use the dev version
- - pip install 'https://github.com/dfm/emcee/archive/master.zip'
+ - pip install 'git+https://github.com/dfm/emcee.git#egg=emcee'
 
 env:
     global:

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setup(name='makecite',
                    'Programming Language :: Python :: 3.5',
                    'Programming Language :: Python :: 3.6'
                    ],
-      entry_points=entry_points
+      entry_points=entry_points, install_requires=['cffconvert']
       )


### PR DESCRIPTION
It's possible that this PR is useless because so few packages install their CITATION files, but I wrote a function that will scrape BibTeX from them if available. If it is a CITATION.cff file, I use the [CFF converter package](https://github.com/citation-file-format/cff-converter-python) to convert to BibTeX.